### PR TITLE
Added NotImplemented OCPP1.6. error code

### DIFF
--- a/ext/SimpleR.Ocpp/OcppErrorCode.cs
+++ b/ext/SimpleR.Ocpp/OcppErrorCode.cs
@@ -6,6 +6,11 @@ namespace SimpleR.Ocpp;
 public enum OcppErrorCode
 {
     /// <summary>
+    /// Requested Action is not known by receiver
+    /// </summary>
+    NotImplemented,
+
+    /// <summary>
     /// Requested Action is recognized but not supported by the receiver
     /// </summary>
     NotSupported,


### PR DESCRIPTION
As per OCPP1.6. standard, the valid error code is also NotImplemented.
![{A6EFA402-1BB4-45EB-9777-65429DCA972E}](https://github.com/user-attachments/assets/d9276d40-a355-4d24-9088-caf9a144e605)
