### PR TITLE
Net9 and keep alive strategies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,22 @@
     <PackageVersion Include="coverlet.collector" Version="[6.0.0,)" />
     <PackageVersion Include="FluentAssertions" Version="[6.12.0,)" />
     <PackageVersion Include="Nuke.Common" Version="8.0.0"  />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.21" />
+	<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,17 +14,6 @@
     <PackageVersion Include="coverlet.collector" Version="[6.0.0,)" />
     <PackageVersion Include="FluentAssertions" Version="[6.12.0,)" />
     <PackageVersion Include="Nuke.Common" Version="8.0.0"  />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.21" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.21" />
-	<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.9" />

--- a/SimpleR.sln
+++ b/SimpleR.sln
@@ -23,13 +23,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleR.Protocol.Tests", "t
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "general", "general", "{43182ADA-7F04-4E48-A722-7D5C77125B91}"
 	ProjectSection(SolutionItems) = preProject
-		global.json = global.json
+		Common.nonprod.props = Common.nonprod.props
+		Common.prod.props = Common.prod.props
+		Common.props = Common.props
 		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
 		LICENSE = LICENSE
 		README.md = README.md
-		Common.nonprod.props = Common.nonprod.props
-		Common.props = Common.props
-		Common.prod.props = Common.prod.props
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PingPong.Server.Tests", "test\PingPong.Server.Tests\PingPong.Server.Tests.csproj", "{F8A42439-AA4C-4F97-9EB8-68AB761ED725}"
@@ -58,8 +58,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleOcpp.Server", "exampl
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ext", "ext", "{813A63E0-FB31-48A3-AC0D-D4F3C469706A}"
 	ProjectSection(SolutionItems) = preProject
-		ext\Directory.Packages.props = ext\Directory.Packages.props
 		ext\Directory.Build.props = ext\Directory.Build.props
+		ext\Directory.Packages.props = ext\Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleR.Ocpp", "ext\SimpleR.Ocpp\SimpleR.Ocpp.csproj", "{531643BE-44A4-404B-A3BB-6C44BC7C49D9}"
@@ -67,89 +67,90 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Publish|Any CPU = Publish|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Publish|Any CPU.ActiveCfg = Publish|Any CPU
 		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Publish|Any CPU.Build.0 = Publish|Any CPU
+		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20A21F54-8F8C-42FD-9870-CA959E2420AB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Publish|Any CPU.ActiveCfg = Publish|Any CPU
 		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Publish|Any CPU.Build.0 = Publish|Any CPU
+		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17EA092C-EA22-4DCF-911D-C59E1483F01C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Publish|Any CPU.ActiveCfg = Publish|Any CPU
 		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Publish|Any CPU.Build.0 = Publish|Any CPU
+		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5F7A5F2-F59A-4221-8E53-C4DBCAD5107E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Publish|Any CPU.ActiveCfg = Publish|Any CPU
 		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Publish|Any CPU.Build.0 = Publish|Any CPU
+		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8A42439-AA4C-4F97-9EB8-68AB761ED725}.Release|Any CPU.Build.0 = Release|Any CPU
 		{588BD3C2-2835-4208-8469-C0652228279D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{588BD3C2-2835-4208-8469-C0652228279D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{588BD3C2-2835-4208-8469-C0652228279D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{588BD3C2-2835-4208-8469-C0652228279D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{588BD3C2-2835-4208-8469-C0652228279D}.Publish|Any CPU.ActiveCfg = Publish|Any CPU
 		{588BD3C2-2835-4208-8469-C0652228279D}.Publish|Any CPU.Build.0 = Publish|Any CPU
+		{588BD3C2-2835-4208-8469-C0652228279D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{588BD3C2-2835-4208-8469-C0652228279D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{813E378E-1E13-4C9E-BBDC-244A6749AB86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{813E378E-1E13-4C9E-BBDC-244A6749AB86}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{813E378E-1E13-4C9E-BBDC-244A6749AB86}.Publish|Any CPU.ActiveCfg = Publish|Any CPU
+		{813E378E-1E13-4C9E-BBDC-244A6749AB86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{813E378E-1E13-4C9E-BBDC-244A6749AB86}.Release|Any CPU.Build.0 = Release|Any CPU
 		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33E383E6-0383-4CE0-93D7-1A513A38356F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CE41E4C-7C34-4B25-8135-C6EF9FF01DF2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9910C92-BEBB-416F-9CBB-78EFD6B2F5F3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53FCFE84-1E7C-4ECF-ABEC-7D76459FC3BB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29}.Release|Any CPU.Build.0 = Release|Any CPU
 		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{531643BE-44A4-404B-A3BB-6C44BC7C49D9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {16103AB9-C01C-45A5-AD4C-93493D8E241E}
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{20A21F54-8F8C-42FD-9870-CA959E2420AB} = {49922A29-C6AC-4852-8596-163816E57B24}
@@ -164,5 +165,8 @@ Global
 		{8CA715D9-6491-42C2-878D-6FBDA9D9B87C} = {D1E4601A-E2A0-43AC-8D33-B05D0001C88F}
 		{1EFE8056-F4BD-4ED0-B7AB-5B61BFE35C29} = {4BEDDC2A-CC7B-4650-BC97-AF81DE36D351}
 		{531643BE-44A4-404B-A3BB-6C44BC7C49D9} = {813A63E0-FB31-48A3-AC0D-D4F3C469706A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {16103AB9-C01C-45A5-AD4C-93493D8E241E}
 	EndGlobalSection
 EndGlobal

--- a/ext/SimpleR.Ocpp/SimpleR.Ocpp.csproj
+++ b/ext/SimpleR.Ocpp/SimpleR.Ocpp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/ext/SimpleR.Ocpp/SimpleR.Ocpp.csproj
+++ b/ext/SimpleR.Ocpp/SimpleR.Ocpp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "9.0.0",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/SimpleR/Internal/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SimpleR/Internal/ConnectionEndpointRouteBuilderExtensions.cs
@@ -31,8 +31,10 @@ internal static class ConnectionEndpointRouteBuilderExtensions
         if (options.WebSockets.KeepAliveInterval is not null)
             webSocketOptions.KeepAliveInterval = (TimeSpan)options.WebSockets.KeepAliveInterval;
 
+#if NET9_0_OR_GREATER
         if (options.WebSockets.KeepAliveTimeout is not null)
             webSocketOptions.KeepAliveTimeout = (TimeSpan)options.WebSockets.KeepAliveTimeout;
+#endif
 
         app.UseWebSockets(webSocketOptions);
         app.Run(c => dispatcher.ExecuteAsync(c, options, connectionDelegate));

--- a/src/SimpleR/Internal/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SimpleR/Internal/ConnectionEndpointRouteBuilderExtensions.cs
@@ -26,6 +26,14 @@ internal static class ConnectionEndpointRouteBuilderExtensions
         
         // build the execute handler part of the protocol
         var app = endpoints.CreateApplicationBuilder();
+
+        var webSocketOptions = new WebSocketOptions();
+        if (options.WebSockets.KeepAliveInterval is not null)
+            webSocketOptions.KeepAliveInterval = (TimeSpan)options.WebSockets.KeepAliveInterval;
+
+        if (options.WebSockets.KeepAliveTimeout is not null)
+            webSocketOptions.KeepAliveTimeout = (TimeSpan)options.WebSockets.KeepAliveTimeout;
+
         app.UseWebSockets();
         app.Run(c => dispatcher.ExecuteAsync(c, options, connectionDelegate));
         var executeHandler = app.Build();

--- a/src/SimpleR/Internal/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SimpleR/Internal/ConnectionEndpointRouteBuilderExtensions.cs
@@ -34,7 +34,7 @@ internal static class ConnectionEndpointRouteBuilderExtensions
         if (options.WebSockets.KeepAliveTimeout is not null)
             webSocketOptions.KeepAliveTimeout = (TimeSpan)options.WebSockets.KeepAliveTimeout;
 
-        app.UseWebSockets();
+        app.UseWebSockets(webSocketOptions);
         app.Run(c => dispatcher.ExecuteAsync(c, options, connectionDelegate));
         var executeHandler = app.Build();
 

--- a/src/SimpleR/SimpleR.csproj
+++ b/src/SimpleR/SimpleR.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  	<TargetFrameworks>net9.0</TargetFrameworks>
+  	<TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
 	<Title>SimpleR.Server</Title>
 	<PackageId>SimpleR.Server</PackageId>
     <PackageTags>simpler websocket aspnetcore</PackageTags>

--- a/src/SimpleR/SimpleR.csproj
+++ b/src/SimpleR/SimpleR.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+  	<TargetFrameworks>net9.0</TargetFrameworks>
 	<Title>SimpleR.Server</Title>
 	<PackageId>SimpleR.Server</PackageId>
     <PackageTags>simpler websocket aspnetcore</PackageTags>

--- a/src/SimpleR/WebSocketOptions.cs
+++ b/src/SimpleR/WebSocketOptions.cs
@@ -23,4 +23,14 @@ public class WebSocketOptions
     public TransferFormat TransferFormat { get; set; } = TransferFormat.Text;
     
     internal bool FramePackets { get; set; }
+
+    /// <summary>
+    /// The interval to send keep-alive frames. This is a heart-beat that keeps the connection alive.
+    /// </summary>
+    public TimeSpan? KeepAliveInterval { get; set; }
+
+    /// <summary>
+    /// The time to wait for a Pong frame response after sending a Ping frame. If the time is exceeded the websocket will be aborted.
+    /// </summary>
+    public TimeSpan? KeepAliveTimeout { get; set; }
 }

--- a/src/SimpleR/WebSocketOptions.cs
+++ b/src/SimpleR/WebSocketOptions.cs
@@ -29,8 +29,10 @@ public class WebSocketOptions
     /// </summary>
     public TimeSpan? KeepAliveInterval { get; set; }
 
+#if NET9_0_OR_GREATER
     /// <summary>
     /// The time to wait for a Pong frame response after sending a Ping frame. If the time is exceeded the websocket will be aborted.
     /// </summary>
     public TimeSpan? KeepAliveTimeout { get; set; }
+#endif
 }

--- a/test/PingPong.Server.Tests/PingPong.Server.Tests.csproj
+++ b/test/PingPong.Server.Tests/PingPong.Server.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Unit test project for PingPong SimpleR Server Scenario</Description>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <IsTestProject>true</IsTestProject>
         <Configurations>Debug;Release;Publish</Configurations>
         <Platforms>AnyCPU</Platforms>
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="FluentAssertions" /> 
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Websocket.Client" />

--- a/test/PingPong.Server.Tests/PingPong.Server.Tests.csproj
+++ b/test/PingPong.Server.Tests/PingPong.Server.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Unit test project for PingPong SimpleR Server Scenario</Description>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <IsTestProject>true</IsTestProject>
         <Configurations>Debug;Release;Publish</Configurations>
         <Platforms>AnyCPU</Platforms>

--- a/test/PingPong.Server/PingPong.Server.csproj
+++ b/test/PingPong.Server/PingPong.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <Configurations>Debug;Release;Publish</Configurations>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>

--- a/test/PingPong.Server/PingPong.Server.csproj
+++ b/test/PingPong.Server/PingPong.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <Configurations>Debug;Release;Publish</Configurations>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>

--- a/test/PingPong.Server/Properties/launchSettings.json
+++ b/test/PingPong.Server/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "PingPong.Server": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:59580;http://localhost:59581"
+    }
+  }
+}

--- a/test/SimpleR.Ocpp.Benchmarks/SimpleR.Ocpp.Benchmarks.csproj
+++ b/test/SimpleR.Ocpp.Benchmarks/SimpleR.Ocpp.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/test/SimpleR.Ocpp.Tests/SimpleR.Ocpp.Tests.csproj
+++ b/test/SimpleR.Ocpp.Tests/SimpleR.Ocpp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/test/SimpleR.Ocpp.Tests/SimpleR.Ocpp.Tests.csproj
+++ b/test/SimpleR.Ocpp.Tests/SimpleR.Ocpp.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,15 +10,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="coverlet.collector" />
         <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/SimpleR.Protocol.Tests/SimpleR.Protocol.Tests.csproj
+++ b/test/SimpleR.Protocol.Tests/SimpleR.Protocol.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -10,10 +10,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="System.IO.Pipelines"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="System.IO.Pipelines" />
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/test/SimpleR.Protocol.Tests/SimpleR.Protocol.Tests.csproj
+++ b/test/SimpleR.Protocol.Tests/SimpleR.Protocol.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
Hello,

this is PR for [issue](https://github.com/vadrsa/SimpleR/issues/32).

## Summary
- Upgraded the solution to use .NET 9.
- Added an option to configure WebSocket middleware settings through WebSocketConnectionDispatcherOptions.

## Notes

- Visual Studio reformatted several files automatically. What formatter or settings should we standardize on to avoid unnecessary diffs and merge conflicts in the future?
- Projects under the /Example folder are still targeting .NET 8. These can be updated once the new NuGet packages are published.
- Visual studio keept generating launchSettings.json for PingPong.Server so I kept it in the project
- All tests have passes

I will be happy to hear your thoughts and suggestions.
 